### PR TITLE
Allow vms connected with a router access to eips on this router

### DIFF
--- a/src/zvr/plugin/dnat.go
+++ b/src/zvr/plugin/dnat.go
@@ -96,7 +96,7 @@ func setRuleInTree(tree *server.VyosConfigTree, rules []dnatInfo) {
 			fmt.Sprintf("description %v", des),
 			fmt.Sprintf("destination address %v", r.VipIp),
 			fmt.Sprintf("destination port %v", sport),
-			fmt.Sprintf("inbound-interface %v", pubNicName),
+			fmt.Sprintf("inbound-interface any"),
 			fmt.Sprintf("protocol %v", strings.ToLower(r.ProtocolType)),
 			fmt.Sprintf("translation address %v", r.PrivateIp),
 			fmt.Sprintf("translation port %v", dport),

--- a/src/zvr/plugin/eip.go
+++ b/src/zvr/plugin/eip.go
@@ -43,9 +43,9 @@ func setEip(tree *server.VyosConfigTree, eip eipInfo) {
 	nicname, err := utils.GetNicNameByIp(eip.VipIp); utils.PanicOnError(err)
 
 	if r := tree.FindSnatRuleDescription(des); r == nil {
-		tree.SetSnatWithStartRuleNumber(EIP_SNAT_START_RULE_NUM,
+		tree.SetSnat(
 			fmt.Sprintf("description %v", des),
-			fmt.Sprintf("outbound-interface %v", nicname),
+			fmt.Sprintf("outbound-interface any"),
 			fmt.Sprintf("source address %v", eip.GuestIp),
 			fmt.Sprintf("translation address %v", eip.VipIp),
 		)
@@ -54,7 +54,7 @@ func setEip(tree *server.VyosConfigTree, eip eipInfo) {
 	if r := tree.FindDnatRuleDescription(des); r == nil {
 		tree.SetDnat(
 			fmt.Sprintf("description %v", des),
-			fmt.Sprintf("inbound-interface %v", nicname),
+			fmt.Sprintf("inbound-interface any"),
 			fmt.Sprintf("destination address %v", eip.VipIp),
 			fmt.Sprintf("translation address %v", eip.GuestIp),
 		)


### PR DESCRIPTION
According to the current nat rules, vms connected with a router
can not access to the eips on this router, because rules in nat
won't process packets from guest network.

This patch changes the rules to make it accessible.

Besides, found a bug about snat rule of eip, also fixed in this patch.

For zxwing/premium#1638