### PR TITLE
A few fixes to zvrboot when running under ESX

### DIFF
--- a/src/zvr/zvrboot.go
+++ b/src/zvr/zvrboot.go
@@ -74,10 +74,14 @@ func parseEsxBootInfo() {
 			return false
 		}
 
-		err := utils.MkdirForFile(BOOTSTRAP_INFO_CACHE, 0666); utils.PanicOnError(err)
+		content, err := ioutil.ReadFile(TMP_LOCATION_FOR_ESX); utils.PanicOnError(err)
+		if err = json.Unmarshal(content, &bootstrapInfo); err != nil {
+			panic(errors.Wrap(err, fmt.Sprintf("unable to JSON parse:\n %s", string(content))))
+		}
+
+		err = utils.MkdirForFile(BOOTSTRAP_INFO_CACHE, 0666); utils.PanicOnError(err)
 		err = os.Rename(TMP_LOCATION_FOR_ESX, BOOTSTRAP_INFO_CACHE); utils.PanicOnError(err)
 		err = os.Chmod(BOOTSTRAP_INFO_CACHE, 0777); utils.PanicOnError(err)
-		content, _ := ioutil.ReadFile(BOOTSTRAP_INFO_CACHE)
 		log.Debugf("recieved bootstrap info:\n%s", string(content))
 		return true
 	}, time.Duration(300)*time.Second, time.Duration(1)*time.Second)
@@ -329,10 +333,10 @@ func startZvr()  {
 func main() {
 	utils.InitLog("/home/vyos/zvr/zvrboot.log", false)
 	waitIptablesServiceOnline()
-	waitVirtioPortOnline()
 	if isOnVMwareHypervisor() {
 		parseEsxBootInfo()
 	} else {
+		waitVirtioPortOnline()
 		parseKvmBootInfo()
 	}
 	configureVyos()


### PR DESCRIPTION
1. Wait virtio port iff. on KVM hypervisor
2. Unmarshal the bootstrap info for further processing

Signed-off-by: David Lee <live4thee@gmail.com>