### PR TITLE
[1.9.x] A few fixes to zvrboot on ESX

### DIFF
--- a/src/zvr/zvrboot.go
+++ b/src/zvr/zvrboot.go
@@ -306,7 +306,9 @@ func configureVyos()  {
 	tree.Set("system time-zone Asia/Shanghai")
 
 	password := bootstrapInfo["vyosPassword"]; utils.Assert(password != "", "vyosPassword cannot be empty")
-	tree.Setf("system login user vyos authentication plaintext-password %v", password)
+	if !isOnVMwareHypervisor() {
+		tree.Setf("system login user vyos authentication plaintext-password %v", password)
+	}
 
 	tree.Apply(true)
 


### PR DESCRIPTION
1. Wait virtio port iff. on KVM hypervisor
2. Unmarshal the bootstrap info for further processing
3. Do not change the vrouter password on ESX

Signed-off-by: David Lee <live4thee@gmail.com>